### PR TITLE
Dockerize the whole project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.7
+
+# install these before ADD or COPY command to take advantage of caching
+RUN apt-get update && apt-get install -y netcat
+
+RUN mkdir -p /go/src/github.com/nuronialBlock/solvist/solvist/
+WORKDIR /go/src/github.com/nuronialBlock/solvist/solvist
+ADD . /go/src/github.com/nuronialBlock/solvist/solvist
+RUN go get ./...
+EXPOSE 8080
+ENV MONGO_URL mongodb://mongo:27017/solvist
+#ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "2"
+
+services:
+
+  solvist:
+    build:
+      context: .
+      #dockerfile: Dockerfile-alternate
+    image: solvist/solvist     # renames the built image if context is present
+    container_name: solvist
+    command: sh scripts/wait.sh
+    environment:
+      - MONGO_URL=mongodb://solvist_db:27017/solvist
+    ports:
+      - "8080:8080"
+    depends_on:
+      - solvist_db
+    links:
+      - solvist_db
+    tty: true
+
+  solvist_db:
+    image: mongo:3.4
+    container_name: solvist_db
+    expose:
+      - "27017"
+      - "28017" # web status page
+    # volumes:
+    #   - ./data/db:/data/db:rw         # with read and write access

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -m
+go run /go/src/github.com/nuronialBlock/solvist/solvist/cmd/solvistd/main.go
+fg

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo ">> Waiting for solvist_db to start"
+sleep 10
+WAIT=0
+while ! nc -z solvist_db 27017; do
+  sleep 2
+  WAIT=$(($WAIT + 1))
+  if [ "$WAIT" -gt 25 ]; then
+    echo "Error: Timeout wating for solvist_db to start"
+    exit 1
+  fi
+done
+echo ">> solvist_db detected"
+sh scripts/init.sh


### PR DESCRIPTION
Uses default mongo:3.4 image for the database. The `solvist` service depends
on `solvist_db` service, thus `wait.sh` is born.